### PR TITLE
Fix authorizer template mapping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -65,8 +65,10 @@ const LAMBDA_PROXY_REQUEST_TEMPLATE = `
       #set( $map = $context.identity )
       "identity": $loop,
       "domainName": "$context.domainName",
-      #set( $map = $context.authorizer )
-      "authorizer": $loop,
+      #set( $map = $context.authorizer.claims )
+      "authorizer": {
+        claims: $loop
+      },
       "apiId": "$context.apiId"
     },
     "body": "$util.escapeJavaScript("$body").replaceAll("\\\\'", "'")",


### PR DESCRIPTION
Fixed the lambda_proxy template to correctly iterate the properties of $context.authorizer.claims.
The previous template ended up with the following:

```json
"authorizer": {
      "claims": null
}
```